### PR TITLE
Improve add note screen and dark mode issue

### DIFF
--- a/StickySessions.xcodeproj/project.pbxproj
+++ b/StickySessions.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		CC9691572274AB690091E8CD /* RemoteAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9691562274AB690091E8CD /* RemoteAPI.swift */; };
 		CC96915D227519DE0091E8CD /* Urls.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96915C227519DE0091E8CD /* Urls.swift */; };
 		CC96915F227525040091E8CD /* SessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96915E227525040091E8CD /* SessionViewModel.swift */; };
+		CC9A01C82560986D00BADB32 /* UITextViewPH.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A01C72560986D00BADB32 /* UITextViewPH.swift */; };
 		CCF4C7BC227DBA27005365E9 /* NoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4C7BB227DBA27005365E9 /* NoteViewModel.swift */; };
 		CCF4C7BE227DBB74005365E9 /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4C7BD227DBB74005365E9 /* Note.swift */; };
 		CCF4C7C0227DBCB2005365E9 /* NoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4C7BF227DBCB2005365E9 /* NoteCell.swift */; };
@@ -120,6 +121,7 @@
 		CC9691562274AB690091E8CD /* RemoteAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAPI.swift; sourceTree = "<group>"; };
 		CC96915C227519DE0091E8CD /* Urls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Urls.swift; sourceTree = "<group>"; };
 		CC96915E227525040091E8CD /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
+		CC9A01C72560986D00BADB32 /* UITextViewPH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextViewPH.swift; sourceTree = "<group>"; };
 		CCF4C7BB227DBA27005365E9 /* NoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteViewModel.swift; sourceTree = "<group>"; };
 		CCF4C7BD227DBB74005365E9 /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
 		CCF4C7BF227DBCB2005365E9 /* NoteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCell.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			isa = PBXGroup;
 			children = (
 				D114ED6F23527E2600166E71 /* UIViewController+Spinner.swift */,
+				CC9A01C72560986D00BADB32 /* UITextViewPH.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -741,6 +744,7 @@
 				CCF4C7BC227DBA27005365E9 /* NoteViewModel.swift in Sources */,
 				CC497EE7227D07F300905AF2 /* ShowSessionViewModel.swift in Sources */,
 				CC497EE4227D058F00905AF2 /* ShowSessionViewController.swift in Sources */,
+				CC9A01C82560986D00BADB32 /* UITextViewPH.swift in Sources */,
 				CC9691572274AB690091E8CD /* RemoteAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StickySessions/Extensions/UITextViewPH.swift
+++ b/StickySessions/Extensions/UITextViewPH.swift
@@ -1,0 +1,73 @@
+//
+//  UITextViewPH.swift
+//  StickySessions
+//
+//  Created by Vinicius Albuquerque on 14/11/20.
+//  Copyright © 2020 CESAR. All rights reserved.
+//
+
+import UIKit
+
+class UITextViewPH: UITextView, UITextViewDelegate {
+    
+    var isPlaceholderShowing = true
+    private var placeholderDefaultText = "Add text here"
+    @IBInspectable var placeholder: String = "" {
+        didSet {
+            showPlaceholder()
+        }
+    }
+    
+    override var text: String! {
+        get {
+            if isPlaceholderShowing {
+                return ""
+            }
+            return super.text
+        }
+        set {
+            super.text = newValue
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        delegate = self
+        setupView()
+        showPlaceholder()
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if isPlaceholderShowing {
+            hidePlaceholder()
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if super.text.isEmpty {
+            showPlaceholder()
+        }
+    }
+    
+    private func setupView() {
+        super.backgroundColor = UIColor.white
+    }
+    
+    private func showPlaceholder() {
+        if (placeholder.isEmpty) {
+            super.text = placeholderDefaultText
+        } else {
+            super.text = placeholder
+        }
+
+        super.textColor = UIColor.gray
+        isPlaceholderShowing = true
+    }
+    
+    private func hidePlaceholder() {
+        super.text = ""
+        super.textColor = nil
+        isPlaceholderShowing = false
+    }
+    
+}

--- a/StickySessions/Storyboard/AddNote.storyboard
+++ b/StickySessions/Storyboard/AddNote.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HpQ-DK-40X">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HpQ-DK-40X">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,23 +17,39 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Type your note" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="c30-fQ-hGn">
-                                <rect key="frame" x="49" y="215" width="319" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d8p-Wi-ZYC">
-                                <rect key="frame" x="0.0" y="106" width="414" height="83"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="mqN-Zs-643" customClass="UITextViewPH" customModule="StickySessions" customModuleProvider="target">
+                                <rect key="frame" x="20" y="64" width="374" height="160"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="160" id="TRw-bp-yaQ"/>
+                                </constraints>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Add note description"/>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GGP-5b-MbY">
+                                <rect key="frame" x="0.0" y="224" width="414" height="180"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="180" id="AGP-rN-jFI"/>
+                                </constraints>
                             </pickerView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="36H-1n-xeu"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="GGP-5b-MbY" firstAttribute="leading" secondItem="36H-1n-xeu" secondAttribute="leading" id="AFX-dy-MWp"/>
+                            <constraint firstItem="GGP-5b-MbY" firstAttribute="trailing" secondItem="36H-1n-xeu" secondAttribute="trailing" id="O1G-ft-uPM"/>
+                            <constraint firstItem="mqN-Zs-643" firstAttribute="top" secondItem="36H-1n-xeu" secondAttribute="top" constant="20" id="WdA-2K-diO"/>
+                            <constraint firstItem="mqN-Zs-643" firstAttribute="leading" secondItem="36H-1n-xeu" secondAttribute="leading" constant="20" id="bnp-kZ-dni"/>
+                            <constraint firstItem="36H-1n-xeu" firstAttribute="trailing" secondItem="mqN-Zs-643" secondAttribute="trailing" constant="20" id="bvh-Ya-NSK"/>
+                            <constraint firstItem="GGP-5b-MbY" firstAttribute="top" secondItem="mqN-Zs-643" secondAttribute="bottom" id="sZh-uT-CJX"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Title" id="usz-3X-xAp">
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="Zhi-M9-blC">
+                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="done" id="Zhi-M9-blC">
                             <connections>
                                 <action selector="addNoteClicked:" destination="HpQ-DK-40X" id="uJb-Yk-dfb"/>
                             </connections>
@@ -42,8 +57,8 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="descriptionTextField" destination="c30-fQ-hGn" id="D5m-6x-LEH"/>
-                        <outlet property="topicPicker" destination="d8p-Wi-ZYC" id="Q74-Ba-ojs"/>
+                        <outlet property="pickerViewTopics" destination="GGP-5b-MbY" id="4cz-my-bC4"/>
+                        <outlet property="textViewNoteDescription" destination="mqN-Zs-643" id="Npl-eT-qUT"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DNX-rL-CH6" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -51,4 +66,12 @@
             <point key="canvasLocation" x="18.840579710144929" y="-19.419642857142858"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/StickySessions/View/AddNote/AddNoteViewController.swift
+++ b/StickySessions/View/AddNote/AddNoteViewController.swift
@@ -9,31 +9,28 @@
 import UIKit
 import RxSwift
 
-class AddNoteViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSource {
-
+class AddNoteViewController: UIViewController, UIPickerViewDataSource,
+                             UIPickerViewDelegate {
+    
+    @IBOutlet weak var textViewNoteDescription: UITextViewPH!
+    @IBOutlet weak var pickerViewTopics: UIPickerView!
     private let disposeBag = DisposeBag()
-
-    var userName: String = ""
-    var desc: String = ""
-    var topic: String = ""
+    
     var addNoteViewModel: AddNoteViewModel?
     var sessionViewModel: SessionViewModel?
     
-    var pickerData: [String] = [String]()
-    
-    @IBOutlet weak var topicPicker: UIPickerView!
-    @IBOutlet weak var descriptionTextField: UITextField!
+    var topics: [String] = [String]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.topicPicker.delegate = self
-        self.topicPicker.dataSource = self
+        self.title = "Create Note"
         
-        pickerData = sessionViewModel!.topics
-        topic = pickerData[0]
-
+        topics = sessionViewModel!.topics
         addNoteViewModel = AddNoteViewModel()
+        
+        pickerViewTopics.dataSource = self
+        pickerViewTopics.delegate = self
     }
     
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
@@ -41,19 +38,23 @@ class AddNoteViewController: UIViewController, UIPickerViewDelegate, UIPickerVie
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return pickerData.count
+        return topics.count
     }
     
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return pickerData[row]
-    }
-    
-    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        topic = pickerData[row]
+    func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+            return NSAttributedString(string: topics[row], attributes: [NSAttributedString.Key.foregroundColor : UIColor.black])
     }
     
     @IBAction func addNoteClicked(_ sender: Any) {
-        desc = descriptionTextField.text ?? ""
+        let desc = textViewNoteDescription.text ?? ""
+        if desc.isEmpty {
+            showEmptyDescriptionWarning()
+            return
+        }
+        
+        let topic = topics[pickerViewTopics.selectedRow(inComponent: 0)]
+        print("Selected topic: ", topic)
+        print("Note description: ", desc)
         
         addNoteViewModel?.addNote(sessionId: sessionViewModel!.id,
                                   desc: desc,
@@ -77,6 +78,17 @@ class AddNoteViewController: UIViewController, UIPickerViewDelegate, UIPickerVie
 
     func fail(errorMsg: String) {
         print("Error: ", errorMsg)
+    }
+    
+    private func showEmptyDescriptionWarning() {
+        print("Cannot add empty text note.")
+        let dialogMessage = UIAlertController(title: "Empty note", message: "Please add a description to your note", preferredStyle: .alert)
+        
+        let ok = UIAlertAction(title: "OK", style: .default, handler: { (action) -> Void in
+            dialogMessage.dismiss(animated: true, completion: nil)
+         })
+        dialogMessage.addAction(ok)
+        self.present(dialogMessage, animated: true, completion: nil)
     }
 
 }

--- a/StickySessions/View/ShowSession/ShowSessionViewController.swift
+++ b/StickySessions/View/ShowSession/ShowSessionViewController.swift
@@ -64,6 +64,8 @@ class ShowSessionViewController: UICollectionViewController {
         let note = self.notesViewModel[indexPath.item]
         cell.labelTopic.text = note.topic
         cell.labelDescription.text = note.description
+        cell.labelTopic.textColor = UIColor.black
+        cell.labelDescription.textColor = UIColor.black
         return cell
     }
     


### PR DESCRIPTION
Improved add note screen to be a little bit more similar to what
will be in future. It depends on the topic passed by the previous
screen for the final version, so for now, I left the view picker.

Set the colors manually so dark mode doesn't make things invisible.